### PR TITLE
Fixed bug with working with multi db contexts with different passwords.

### DIFF
--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
@@ -48,7 +48,7 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.I
 
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             {
-                return true;
+                return false;
             }
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions;
 using AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Utils;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -36,7 +37,8 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.I
 
         }
 
-        public DbContextOptionsExtensionInfo Info => _info ?? new MyDbContextOptionsExtensionInfo((IDbContextOptionsExtension)this);
+        public DbContextOptionsExtensionInfo Info =>
+            _info ??= new MyDbContextOptionsExtensionInfo((IDbContextOptionsExtension)this);
 
         private sealed class MyDbContextOptionsExtensionInfo : DbContextOptionsExtensionInfo
         {
@@ -58,7 +60,10 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.I
 
             public override int GetServiceProviderHashCode()
             {
-                return 0;
+                var password = ((AltairCaNpgsqlContextOptionsExtension)Extension)._password +
+                    ((AltairCaNpgsqlContextOptionsExtension)Extension)._iv;
+                var hash = password.GetHashCode();
+                return hash;
             }
         }
     }

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
@@ -48,7 +48,7 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.I
 
             public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
             {
-                return false;
+                return true;
             }
 
             public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCANpgsqlContextOptionsExtension.cs
@@ -3,31 +3,40 @@ using AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions;
 using AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Utils;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.Internal
 {
-    internal class AltairCaNpgsqlContextOptionsExtension:IDbContextOptionsExtension
+    internal class AltairCaNpgsqlContextOptionsExtension : IDbContextOptionsExtension
     {
-        
-        public AltairCaNpgsqlContextOptionsExtension(string password,EncKeyLength encKeyLength)
+
+        private readonly string _password;
+        private readonly string _iv;
+
+        public AltairCaNpgsqlContextOptionsExtension(string password, EncKeyLength encKeyLength)
         {
             int keyLength = AesUtil.GetKeyLength(encKeyLength);
-            AltairCaFunctionImplementation.Password = AesUtil.PasswordFixer(password,keyLength);
-            AltairCaFunctionImplementation.Iv = AesUtil.IvFixer(password,keyLength);
+            _password = AesUtil.PasswordFixer(password, keyLength);
+            _iv = AesUtil.IvFixer(password, keyLength);
         }
         private DbContextOptionsExtensionInfo _info;
         public void ApplyServices(IServiceCollection services)
         {
-            new EntityFrameworkRelationalServicesBuilder(services).TryAdd<IMethodCallTranslatorPlugin,AltairCaNpgsqlMethodCallTranslatorPlugin>();
+            new EntityFrameworkRelationalServicesBuilder(services)
+                .TryAdd<IMethodCallTranslatorPlugin, AltairCaNpgsqlMethodCallTranslatorPlugin>(
+                    e => new AltairCaNpgsqlMethodCallTranslatorPlugin(
+                        e.GetRequiredService<IRelationalTypeMappingSource>(), e.GetRequiredService<ISqlExpressionFactory>(),
+                        _password, _iv)
+                );
         }
 
         public void Validate(IDbContextOptions options)
         {
-            
+
         }
 
-        public DbContextOptionsExtensionInfo Info => this._info ?? (MyDbContextOptionsExtensionInfo)new MyDbContextOptionsExtensionInfo((IDbContextOptionsExtension)this);
+        public DbContextOptionsExtensionInfo Info => _info ?? new MyDbContextOptionsExtensionInfo((IDbContextOptionsExtension)this);
 
         private sealed class MyDbContextOptionsExtensionInfo : DbContextOptionsExtensionInfo
         {

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCaNpgsqlMethodCallTranslatorPlugin.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/EfExtension/Internal/AltairCaNpgsqlMethodCallTranslatorPlugin.cs
@@ -10,17 +10,17 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
 
 namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.EfExtension.Internal
 {
-    internal class AltairCaNpgsqlMethodCallTranslatorPlugin:IMethodCallTranslatorPlugin
+    internal class AltairCaNpgsqlMethodCallTranslatorPlugin : IMethodCallTranslatorPlugin
     {
         public AltairCaNpgsqlMethodCallTranslatorPlugin(IRelationalTypeMappingSource typeMappingSource,
-            ISqlExpressionFactory sqlExpressionFactory) 
-            
+            ISqlExpressionFactory sqlExpressionFactory, string password, string iv)
+
         {
             if (!(sqlExpressionFactory is NpgsqlSqlExpressionFactory npgsqlSqlExpressionFactory))
             {
                 throw new ArgumentException($"Must be an {nameof(NpgsqlSqlExpressionFactory)}", nameof(sqlExpressionFactory));
             }
-            Translators = new IMethodCallTranslator[] { new AltairCaFunctionImplementation(sqlExpressionFactory), };
+            Translators = new IMethodCallTranslator[] { new AltairCaFunctionImplementation(sqlExpressionFactory, password, iv), };
         }
 
         public IEnumerable<IMethodCallTranslator> Translators { get; }

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/Functions/AltairCAFunctionImplementation.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/Functions/AltairCAFunctionImplementation.cs
@@ -40,6 +40,7 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
            = typeof(NpgsqlFunctionExtensions).GetMethod(
                nameof(NpgsqlFunctionExtensions.NpgDecrypt),
                new[] { typeof(string), typeof(string) });
+       
         public AltairCaFunctionImplementation(ISqlExpressionFactory expressionFactory, string password, string iv)
         {
             _expressionFactory = expressionFactory;

--- a/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/Functions/AltairCAFunctionImplementation.cs
+++ b/AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption/Functions/AltairCAFunctionImplementation.cs
@@ -8,10 +8,10 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
 {
-    internal class AltairCaFunctionImplementation:IMethodCallTranslator
+    internal class AltairCaFunctionImplementation : IMethodCallTranslator
     {
-        public static string Password { get; set; }
-        public static string Iv { get; set; }
+        private readonly string _password;
+        public readonly string _iv;
         private readonly ISqlExpressionFactory _expressionFactory;
 
         private static readonly MethodInfo _encryptMethod
@@ -40,18 +40,20 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
            = typeof(NpgsqlFunctionExtensions).GetMethod(
                nameof(NpgsqlFunctionExtensions.NpgDecrypt),
                new[] { typeof(string), typeof(string) });
-        public AltairCaFunctionImplementation(ISqlExpressionFactory expressionFactory)
+        public AltairCaFunctionImplementation(ISqlExpressionFactory expressionFactory, string password, string iv)
         {
             _expressionFactory = expressionFactory;
+            _password = password;
+            _iv = iv;
         }
 
-        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments,IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
-            
-            var password = _expressionFactory.Constant(Password);
+
+            var password = _expressionFactory.Constant(_password);
             var algoConf = _expressionFactory.Constant("aes-cbc/pad:pkcs");
-            var iv = _expressionFactory.Constant(Iv);
-            
+            var iv = _expressionFactory.Constant(_iv);
+
             if (method == _nonTranslatableEncryptMethod || method == __nonTranslatableDecryptMethod)
             {
                 throw new Exception("Dont use this this will not translate to SQL. Use Decrypt() or Encrypt()");
@@ -59,16 +61,16 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
             if (method == _encryptStringMethod)
             {
                 var value = arguments[0];
-                
-                var aesToHexExpression = AESEncryptionBuild(password, iv,value,algoConf);
+
+                var aesToHexExpression = AESEncryptionBuild(password, iv, value, algoConf);
 
                 return aesToHexExpression;
             }
             if (method == _encryptMethod)
             {
                 var value = arguments[1];
-                
-                var aesToHexExpression = AESEncryptionBuild(password, iv,value,algoConf);
+
+                var aesToHexExpression = AESEncryptionBuild(password, iv, value, algoConf);
 
                 return aesToHexExpression;
             }
@@ -76,71 +78,71 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
             if (method == _decryptMethod)
             {
                 var value = arguments[1];
-                
-                var aesDecryptExpression = AesDecryptExpression(password,iv, value,algoConf);
+
+                var aesDecryptExpression = AesDecryptExpression(password, iv, value, algoConf);
                 return _expressionFactory.Convert(aesDecryptExpression, typeof(string));
             }
             if (method == _decryptStringMethod)
             {
                 var value = arguments[0];
 
-                var aesDecryptExpression = AesDecryptExpression(password, iv,value,algoConf);
+                var aesDecryptExpression = AesDecryptExpression(password, iv, value, algoConf);
                 return _expressionFactory.Convert(aesDecryptExpression, typeof(string));
             }
             return null;
         }
 
-        private SqlFunctionExpression AesDecryptExpression( SqlExpression password,SqlExpression iv, SqlExpression value, SqlExpression algoConf)
+        private SqlFunctionExpression AesDecryptExpression(SqlExpression password, SqlExpression iv, SqlExpression value, SqlExpression algoConf)
         {
             var hexExpression = _expressionFactory.Constant("base64");
             var decodeExpression = _expressionFactory.Function("decode", new List<SqlExpression>()
             {
                 value,
                 hexExpression
-            },true,new List<bool>
+            }, true, new List<bool>
             {
                 true,
                 false
             }, typeof(byte[]));
-            var decryptExpression = _expressionFactory.Function( "decrypt_iv", new List<SqlExpression>()
+            var decryptExpression = _expressionFactory.Function("decrypt_iv", new List<SqlExpression>()
             {
                 decodeExpression,
                 password,
                 iv,
                 algoConf
-            },true,new List<bool>
+            }, true, new List<bool>
             {
                 true,
                 false,
                 false,
                 false
-            },typeof(byte[]));
+            }, typeof(byte[]));
             var decryptConvert = _expressionFactory.Convert(decryptExpression, typeof(byte[]));
             var convertFromExpression = _expressionFactory.Function("convert_from", new List<SqlExpression>()
             {
                 decryptConvert,
                 _expressionFactory.Constant("UTF-8")
-            },true,new List<bool>
+            }, true, new List<bool>
             {
                 true,
                 false
-            },typeof(string));
+            }, typeof(string));
             return convertFromExpression;
         }
 
-        protected virtual SqlFunctionExpression AESEncryptionBuild(SqlExpression password,SqlExpression iv,
+        protected virtual SqlFunctionExpression AESEncryptionBuild(SqlExpression password, SqlExpression iv,
             SqlExpression value, SqlExpression algoConf)
         {
             var hexExpression = _expressionFactory.Constant("base64");
             var convertToBytea = _expressionFactory.Convert(value, typeof(byte[]));
-            var aesEncryptionExpression = _expressionFactory.Function( "encrypt_iv",
+            var aesEncryptionExpression = _expressionFactory.Function("encrypt_iv",
                 new List<SqlExpression>()
                 {
                     convertToBytea,
                     password,
                     iv,
                     algoConf
-                },true,new List<bool>
+                }, true, new List<bool>
                 {
                     true,
                     false,
@@ -151,7 +153,7 @@ namespace AltairCA.EntityFrameworkCore.PostgreSQL.ColumnEncryption.Functions
             {
                 aesEncryptionExpression,
                 hexExpression
-            },true,new List<bool>
+            }, true, new List<bool>
             {
                 true,
                 false


### PR DESCRIPTION
I faced out with issue: I have many database contexts with encrypted columns and each context should have separate passwords. Unfortunately, your library doesn't provide the possibility to manage the situation, because... Please review my changes that should fix the problem. I tested the code a little and it works.

Best regards, Serhiy